### PR TITLE
Align reconciliation with document identifiers and divergence causes

### DIFF
--- a/tecnoloc_reconciliation/models.py
+++ b/tecnoloc_reconciliation/models.py
@@ -37,6 +37,7 @@ class PayfyExpense(BaseRecord):
     match_id: Optional[str] = None
     match_type: Optional[str] = None
     failure_reason: Optional[str] = None
+    failure_cause: Optional[str] = None
 
 
 @dataclass
@@ -45,9 +46,12 @@ class ErpRecord(BaseRecord):
 
     erp_type: str = ""
     reference: Optional[str] = None
+    document_id: Optional[str] = None
+    movement_date: Optional[datetime] = None
     match_id: Optional[str] = None
     match_type: Optional[str] = None
     failure_reason: Optional[str] = None
+    failure_cause: Optional[str] = None
 
 
 @dataclass

--- a/tecnoloc_reconciliation/reports.py
+++ b/tecnoloc_reconciliation/reports.py
@@ -12,7 +12,7 @@ main
         "Categoria": expense.category,
         "ID": expense.expense_id or "",
         "Match": expense.match_type or "",
-        "Motivo": expense.failure_reason or "",
+        "Motivo": (expense.failure_cause or expense.failure_reason or ""),
     }
 main
     payload = {
@@ -21,7 +21,7 @@ main
         "Valor": f"{record.value:.2f}",
         "Tipo": record.erp_type,
         "Match": record.match_type or "",
-        "Motivo": record.failure_reason or "",
+        "Motivo": (record.failure_cause or record.failure_reason or ""),
     }
 main
     return payload


### PR DESCRIPTION
## Summary
- index PayFy expenses by expense_id and match ERP entries through their document identifiers with value and competence validation
- replace tolerance and aggregation matching with explicit divergence classifications while surfacing failure causes for diagnostics and reports
- enrich data models and loaders with document metadata and propagate failure causes across preprocessing and reporting flows

## Testing
- pytest *(fails: pyproject.toml cannot be parsed)*

------
https://chatgpt.com/codex/tasks/task_b_68f15f2de758833388fbec122d675b46