### PR TITLE
Implement automatic competence detection and Excel export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,12 @@ description = "Aplicativo de conciliação PayFy x ERP Protheus"
 authors = [{name = "Tecnoloc"}]
 readme = "README.md"
 requires-python = ">=3.11"
-main
+dependencies = [
+    "openpyxl>=3.1,<4",
+]
 
 [project.scripts]
 tecnoloc-reconciliation = "tecnoloc_reconciliation.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tecnoloc_reconciliation/cli.py
+++ b/tecnoloc_reconciliation/cli.py
@@ -5,30 +5,19 @@ from __future__ import annotations
 import argparse
 from datetime import datetime
 from pathlib import Path
-main
+from typing import Iterable, List, Sequence, Tuple
 
 from . import loader, matcher, preprocess, reports
 from .models import ErpRecord, PayfyExpense
 
 
-main
-def _parse_period(value: str | None) -> datetime:
-    if not value:
-        raise preprocess.PeriodNotProvidedError("Período de conciliação não informado.")
-    try:
-        return datetime.strptime(value, "%d/%m/%Y – %H:%M")
-    except ValueError as exc:
-        raise preprocess.PeriodNotProvidedError(
-            "Período deve estar no formato 'dd/mm/aaaa – hh:mm'."
-        ) from exc
-
-
 def _prepare_data(
-    period: datetime,
     card_path: Path,
     expenses_path: Path,
     erp_path: Path,
-) -> tuple[List[PayfyExpense], List[ErpRecord]]:
+) -> Tuple[List[PayfyExpense], List[ErpRecord]]:
+    """Load and preprocess the PayFy and ERP data."""
+
     # Carrega todos os arquivos para garantir a validação do conteúdo.
     loader.load_payfy_card_summary(card_path)
     payfy_expenses = loader.load_payfy_expenses(expenses_path)
@@ -39,44 +28,143 @@ def _prepare_data(
     preprocess.map_categories(payfy_expenses)
     preprocess.apply_date_rules(payfy_expenses)
     preprocess.ensure_status_validated(payfy_expenses)
-    preprocess.validate_period(payfy_expenses, period)
     preprocess.detect_duplicates(payfy_expenses)
 
     return payfy_expenses, erp_records
 
 
-main
-    period = _parse_period(args.period)
-    card_path = Path(args.cards)
-    expenses_path = Path(args.expenses)
-    erp_path = Path(args.erp)
+def _month_year_key(date: datetime) -> Tuple[int, int]:
+    return date.year, date.month
 
-    if not card_path.exists() or not card_path.is_file():
-        raise FileNotFoundError(f"Arquivo de cartões não encontrado: {card_path}")
-    if not expenses_path.exists() or not expenses_path.is_file():
-        raise FileNotFoundError(f"Arquivo de despesas não encontrado: {expenses_path}")
-    if not erp_path.exists() or not erp_path.is_file():
-        raise FileNotFoundError(f"Arquivo ERP não encontrado: {erp_path}")
 
-    payfy_expenses, erp_records = _prepare_data(period, card_path, expenses_path, erp_path)
-    matcher.reconcile(payfy_expenses, erp_records)
-    diagnostics = preprocess.summarize_failures(payfy_expenses, erp_records)
-    result = reports.build_reconciliation_result(payfy_expenses, erp_records, diagnostics)
-main
+def _extract_payfy_competence(expenses: Iterable[PayfyExpense]) -> Sequence[Tuple[int, int]]:
+    months = {
+        _month_year_key(expense.approval_date)
+        for expense in expenses
+        if expense.approval_date is not None
+    }
+    if not months:
+        raise preprocess.PeriodNotProvidedError(
+            "Não foi possível identificar a competência pelas aprovações do PayFy."
+        )
+    return sorted(months)
+
+
+def _extract_protheus_competence(movements: Sequence[datetime], erp_records: Iterable[ErpRecord]) -> Sequence[Tuple[int, int]]:
+    months = {_month_year_key(moment) for moment in movements}
+    if not months:
+        raw_months = {
+            _month_year_key(record.date)
+            for record in erp_records
+        }
+        months.update(raw_months)
+    if not months:
+        raise preprocess.PeriodNotProvidedError(
+            "Não foi possível identificar a competência pelos lançamentos do Protheus."
+        )
+    return sorted(months)
+
+
+def _confirm_competence(possible_months: Sequence[Tuple[int, int]]) -> datetime:
+    options = ", ".join(f"{month:02d}/{year}" for year, month in possible_months)
+    print(f"Competências detectadas: {options}.")
+    while True:
+        response = input("Confirmar MM/AAAA: ").strip()
+        if not response:
+            print("Informe a competência no formato MM/AAAA.")
+            continue
+        try:
+            confirmed = datetime.strptime(response, "%m/%Y")
+        except ValueError:
+            print("Formato inválido. Utilize MM/AAAA.")
+            continue
+        return confirmed.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _determine_competence(
+    payfy_expenses: Sequence[PayfyExpense],
+    erp_records: Sequence[ErpRecord],
+    protheus_movements: Sequence[datetime],
+) -> datetime:
+    payfy_months = _extract_payfy_competence(payfy_expenses)
+    protheus_months = _extract_protheus_competence(protheus_movements, erp_records)
+
+    combined = sorted(set(payfy_months) | set(protheus_months))
+    if not combined:
+        raise preprocess.PeriodNotProvidedError(
+            "Não foi possível determinar a competência de conciliação."
+        )
+    if len(combined) == 1:
+        year, month = combined[0]
+        return datetime(year, month, 1)
+
+    return _confirm_competence(combined)
+
+
+def _ensure_input_file(path: Path, *, description: str, parser: argparse.ArgumentParser) -> Path:
+    if not path.exists() or not path.is_file():
+        parser.error(f"Arquivo {description} não encontrado: {path}")
+    return path
 
 
 def build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Conciliação PayFy x ERP – Tecnoloc")
-    parser.add_argument("--period", help="Período de conciliação (dd/mm/aaaa – hh:mm)")
-main
+    parser.add_argument(
+        "--payfy-card-summary",
+        required=True,
+        type=Path,
+        help="Caminho para o resumo de cartões PayFy.",
+    )
+    parser.add_argument(
+        "--payfy-expenses",
+        required=True,
+        type=Path,
+        help="Caminho para a planilha de despesas detalhadas do PayFy.",
+    )
+    parser.add_argument(
+        "--erp-records",
+        required=True,
+        type=Path,
+        help="Caminho para o relatório financeiro do Protheus.",
+    )
+    parser.add_argument(
+        "--erp-movements",
+        required=True,
+        type=Path,
+        help="Caminho para a planilha de movimentos do Protheus (campo data_mov).",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Caminho do arquivo Excel a ser gerado com o resultado da conciliação.",
+    )
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: List[str] | None = None) -> int:
     parser = build_argument_parser()
     args = parser.parse_args(argv)
+
     try:
-main
+        card_path = _ensure_input_file(args.payfy_card_summary, description="de cartões do PayFy", parser=parser)
+        expenses_path = _ensure_input_file(args.payfy_expenses, description="de despesas do PayFy", parser=parser)
+        erp_path = _ensure_input_file(args.erp_records, description="financeiro do Protheus", parser=parser)
+        movements_path = _ensure_input_file(args.erp_movements, description="de movimentos do Protheus", parser=parser)
+
+        payfy_expenses, erp_records = _prepare_data(card_path, expenses_path, erp_path)
+        protheus_movements = loader.load_erp_movements(movements_path)
+
+        competence = _determine_competence(payfy_expenses, erp_records, protheus_movements)
+        preprocess.validate_period(payfy_expenses, competence)
+
+        matcher.reconcile(payfy_expenses, erp_records)
+        diagnostics = preprocess.summarize_failures(payfy_expenses, erp_records)
+        result = reports.build_reconciliation_result(payfy_expenses, erp_records, diagnostics)
+
+        output_path: Path = args.output
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        reports.write_excel_report(result, output_path)
         return 0
     except preprocess.PeriodNotProvidedError as error:
         parser.error(str(error))
@@ -84,9 +172,14 @@ main
         parser.error(str(error))
     except FileNotFoundError as error:
         parser.error(str(error))
+    except RuntimeError as error:
+        parser.error(str(error))
+    except OSError as error:
+        parser.error(f"Falha ao gravar o relatório: {error}")
 
     return 1
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/tecnoloc_reconciliation/loader.py
+++ b/tecnoloc_reconciliation/loader.py
@@ -1,9 +1,13 @@
-main
+"""Data loading utilities for the Tecnoloc reconciliation pipeline."""
+
+from __future__ import annotations
+
+import csv
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, Iterator, List, Tuple
 
-main
+from .models import ErpRecord, PayfyExpense
 
 
 class DataValidationError(RuntimeError):
@@ -11,23 +15,103 @@ class DataValidationError(RuntimeError):
 
 
 def _parse_date(value: str, *, field_name: str) -> datetime:
-main
+    """Parse a textual date supporting the formats used in the reports."""
+
+    if not value:
+        raise DataValidationError(f"Data vazia no campo '{field_name}'.")
+
+    normalized = value.strip()
+    formats = (
+        "%d/%m/%Y %H:%M",
+        "%d/%m/%Y %H:%M:%S",
+        "%d/%m/%Y",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d",
+    )
+    for date_format in formats:
+        try:
+            return datetime.strptime(normalized, date_format)
         except ValueError:
             continue
     raise DataValidationError(f"Data inválida '{value}' no campo '{field_name}'.")
 
 
 def _parse_float(value: str, *, field_name: str) -> float:
-    normalized = value.replace("R$", "").replace("$", "").replace(" ", "")
-main
+    normalized = value.replace("R$", "").replace("$", "").replace(" ", "").replace(".", "").replace(",", ".")
     try:
         return float(normalized)
     except ValueError as exc:
         raise DataValidationError(f"Valor inválido '{value}' no campo '{field_name}'.") from exc
 
 
+def _read_csv_rows(path: Path) -> Iterator[Dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as csv_file:
+        preview = csv_file.readline()
+        csv_file.seek(0)
+        delimiter = ";" if preview.count(";") > preview.count(",") else ","
+        reader = csv.DictReader(csv_file, delimiter=delimiter)
+        if reader.fieldnames is None:
+            return iter(())
+        for row in reader:
+            cleaned = {
+                (key or "").strip(): (value.strip() if isinstance(value, str) else "" if value is None else str(value))
+                for key, value in row.items()
+            }
+            if not any(cleaned.values()):
+                continue
+            yield cleaned
+
+
+def _read_excel_rows(path: Path) -> Iterator[Dict[str, str]]:
+    try:
+        from openpyxl import load_workbook
+    except ModuleNotFoundError as exc:
+        raise DataValidationError(
+            "Leitura de arquivos .xlsx requer a dependência 'openpyxl'."
+        ) from exc
+
+    workbook = load_workbook(filename=path, read_only=True, data_only=True)
+    try:
+        worksheet = workbook.active
+        rows = worksheet.iter_rows(values_only=True)
+        try:
+            headers = next(rows)
+        except StopIteration:
+            return
+
+        normalized_headers = [str(header).strip() if header is not None else "" for header in headers]
+        for values in rows:
+            record = {}
+            empty = True
+            for header, value in zip(normalized_headers, values or ()):  # type: ignore[arg-type]
+                if header == "":
+                    continue
+                if isinstance(value, datetime):
+                    text = value.strftime("%d/%m/%Y %H:%M:%S")
+                elif value is None:
+                    text = ""
+                else:
+                    text = str(value).strip()
+                if text:
+                    empty = False
+                record[header] = text
+            if empty:
+                continue
+            yield record
+    finally:
+        workbook.close()
+
+
 def _read_rows(path: Path) -> Iterable[Dict[str, str]]:
-main
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(f"Arquivo não encontrado: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix in {".csv"}:
+        return list(_read_csv_rows(path))
+    if suffix in {".xlsx", ".xlsm"}:
+        return list(_read_excel_rows(path))
+    raise DataValidationError(f"Formato de arquivo não suportado: '{path.suffix}'.")
 
 
 def load_payfy_expenses(path: Path) -> List[PayfyExpense]:
@@ -108,3 +192,23 @@ def load_payfy_card_summary(path: Path) -> List[Tuple[str, float, float]]:
         final_balance = _parse_float(row["Saldo Final"], field_name="Saldo Final")
         summary.append((team, initial_balance, final_balance))
     return summary
+
+
+def load_erp_movements(path: Path) -> List[datetime]:
+    """Load the ERP movement report to analyse the `data_mov` competence."""
+
+    rows = list(_read_rows(path))
+    if not rows:
+        return []
+
+    dates: List[datetime] = []
+    for index, row in enumerate(rows, start=2):
+        matching_key = next((key for key in row if key.lower() == "data_mov"), None)
+        if not matching_key:
+            raise DataValidationError("Campo obrigatório 'data_mov' não encontrado no arquivo de movimentos do Protheus.")
+        value = row.get(matching_key, "").strip()
+        if not value:
+            raise DataValidationError(f"Campo 'data_mov' vazio na linha {index}.")
+        dates.append(_parse_date(value, field_name="data_mov"))
+    return dates
+


### PR DESCRIPTION
## Summary
- add required CLI arguments for the four reconciliation inputs and Excel output
- infer the reconciliation competence from PayFy approvals and Protheus movements, prompting when there is a mismatch
- chain the loaders, reconciliation pipeline and Excel report writer and add the supporting loader/report helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f15f278e208333b2bf534bff014861